### PR TITLE
handle possibly conflicting prefix search

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -253,7 +253,7 @@ func (n *node) search(path string) (*node, []string) {
 
 		nextChar := path[0]
 		for i, c := range []byte(n.indices) {
-			if c == nextChar {
+			if c == nextChar && strings.HasPrefix(path, n.literals[i].path) {
 				if found, params := n.literals[i].search(path); found != nil {
 					return found, params
 				}

--- a/tree_test.go
+++ b/tree_test.go
@@ -470,8 +470,6 @@ func TestTreeWildcard_RecursesIntoPrefixIfEntirePrefixMatches(t *testing.T) {
 		tree.addRoute(route, fakeHandler(route))
 	}
 
-	// printChildren(tree, "")
-
 	checkRequests(t, tree, testRequests{
 		// could be confused with /fe... => /feed/:collectionSlug/tagged/:tagSlug
 		{"/fernando-henrique-cardoso/tempos-confusos-e416041e56c2", false, "/:collectionSlug/:postId", []string{"collectionSlug", "postId"}, []string{"fernando-henrique-cardoso", "tempos-confusos-e416041e56c2"}},

--- a/tree_test.go
+++ b/tree_test.go
@@ -452,3 +452,33 @@ func TestTreeDenormalizePath(t *testing.T) {
 		t.Fatalf("Expected %s to be %s", p, "/bar/hello/world/foo")
 	}
 }
+
+func TestTreeWildcard_RecursesIntoPrefixIfEntirePrefixMatches(t *testing.T) {
+	tree := &node{}
+
+	routes := [...]string{
+		"/feed/:collectionSlug/tagged/:tagSlug",
+		"/:collectionSlug/tagged/:tagSlug",
+		"/:collectionSlug",
+		"/:collectionSlug/:postId",
+		"/p/:postId",
+		"/s/:sequenceSlug/:postId",
+		"/s/:sequenceSlug/share/:channel",
+		"/s/:sequenceSlug",
+	}
+	for _, route := range routes {
+		tree.addRoute(route, fakeHandler(route))
+	}
+
+	// printChildren(tree, "")
+
+	checkRequests(t, tree, testRequests{
+		// could be confused with /fe... => /feed/:collectionSlug/tagged/:tagSlug
+		{"/fernando-henrique-cardoso/tempos-confusos-e416041e56c2", false, "/:collectionSlug/:postId", []string{"collectionSlug", "postId"}, []string{"fernando-henrique-cardoso", "tempos-confusos-e416041e56c2"}},
+		// could be confused with /s/:collectionSlug/s... => /s/:sequenceSlug/share/:channel
+		{"/s/canarycuddles/sequence-test-33b695a20129", false, "/s/:sequenceSlug/:postId", []string{"sequenceSlug", "postId"}, []string{"canarycuddles", "sequence-test-33b695a20129"}},
+		{"/s/story/strategies-for-seizing-the-day-5a8be91a5346", false, "/:collectionSlug", []string{"collectionSlug"}, []string{"eduardospub"}},
+	})
+
+	checkPriorities(t, tree)
+}


### PR DESCRIPTION
Given the following routes:

```
/feed/:collectionSlug/tagged/:tagSlug
/:collectionSlug/tagged/:tagSlug
/:collectionSlug
/:collectionSlug/:postId
/p/:postId
/s/:sequenceSlug/:postId
/s/:sequenceSlug/share/:channel
/s/:sequenceSlug
```

which produces the following internal tree:

```
 08 /[4] <nil> true 1 sfp
 03  s/[1] <nil> true 0
 02    :[1] 0x1297850 false 2
 02     /[2] <nil> true 0 s
 01      share/[1] <nil> true 0
 01            :[0] 0x1297850 false 2
 01      :[0] 0x1297850 false 2
 01  feed/[1] <nil> true 0
 01       :[1] <nil> false 2
 01        /tagged/[1] <nil> true 0
 01                :[0] 0x1297850 false 2
 01  p/[1] <nil> true 0
 01    :[0] 0x1297850 false 2
 02  :[1] 0x1297850 false 2
 02   /[2] <nil> true 0 t
 01    tagged/[1] <nil> true 0
 01           :[0] 0x1297850 false 2
 01    :[0] 0x1297850 false 2
 ```


And, given the following path:

```
/fernando-henrique-cardoso/tempos-confusos-e416041e56c2
```

the previous implementation would incorrectly recurse into the `feed/` node bc of the possibly confusing `f` prefix in the first segment of the url. this pr changes the behavior to make sure the entire segment of the url matches the node's prefix before recursing 