### PR TITLE
add an option to prefer using the raw request path when available and implement TSR as proper redirection instead of mutating the original request

### DIFF
--- a/router.go
+++ b/router.go
@@ -98,11 +98,11 @@ type Router struct {
 	// unrecovered panics.
 	PanicHandler func(http.ResponseWriter, *http.Request, interface{})
 
-	// If enabled, the router try use URL.RawPath if one is found for route matching
+	// If enabled, the router prefers URL.RawPath for route matching instead of the unescaped URL.Path.
 	UseRawPath bool
 
-	// If enabled, the router will match remove extra slashes from the URL before matching. It
-	// not mutate the original URL.
+	// If enabled, the router will remove extra slashes from the path before route matching. It
+	// will not mutate the original URL.
 	CleanPath bool
 
 	// Enables automatic redirection if the current route can't be matched but a
@@ -297,8 +297,8 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// This isn't ideal bc we're secretly matching against a different URL
-	// that what we'll pass on to the handler but it solves our existing use
-	// case and for the most cases it will be ok.
+	// than what we'll pass on to the handler but it solves our existing use
+	// case and for the most part it will be ok.
 	if r.CleanPath {
 		path = CleanPath(path)
 	}

--- a/router.go
+++ b/router.go
@@ -98,17 +98,19 @@ type Router struct {
 	// unrecovered panics.
 	PanicHandler func(http.ResponseWriter, *http.Request, interface{})
 
-	// If enabled, the router will fix the current request path before looking for a match.
-	// Superfluous path elements like ../ or // are removed. For example /foo/// and /..//foo/ could
-	// be handled as /foo.
-	// TryFixedTrailingSlash is independent of this option.
+	// If enabled, the router try use URL.RawPath if one is found for route matching
+	UseRawPath bool
+
+	// If enabled, the router will match remove extra slashes from the URL before matching. It
+	// not mutate the original URL.
 	CleanPath bool
 
-	// If the current route can't be matched but a handler for the path with/without
-	// the trailing slash exists, the router will use that handler.
+	// Enables automatic redirection if the current route can't be matched but a
+	// handler for the path with (without) the trailing slash exists.
 	// For example if /foo/ is requested but a route only exists for /foo, the
-	// request will still be served.
-	TryFixedTrailingSlash bool
+	// client is redirected to /foo with http status code 301 for GET requests
+	// and 308 for all other request methods.
+	RedirectTrailingSlash bool
 }
 
 // Make sure the Router conforms with the http.Handler interface
@@ -119,8 +121,9 @@ func New() *Router {
 	return &Router{
 		HandleMethodNotAllowed: true,
 		HandleOPTIONS:          true,
-		CleanPath:              true,
-		TryFixedTrailingSlash:  true,
+		RedirectTrailingSlash:  true,
+		UseRawPath:             false,
+		CleanPath:              false,
 	}
 }
 
@@ -288,15 +291,19 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		defer r.recv(w, req)
 	}
 
-	var path string
-	if r.CleanPath && req.URL.Path != "*" {
-		path = CleanPath(req.URL.EscapedPath())
-	} else {
-		path = req.URL.EscapedPath()
+	path := req.URL.Path
+	if r.UseRawPath && len(req.URL.RawPath) > 0 {
+		path = req.URL.RawPath
+	}
+
+	// This isn't ideal bc we're secretly matching against a different URL
+	// that what we'll pass on to the handler but it solves our existing use
+	// case and for the most cases it will be ok.
+	if r.CleanPath {
+		path = CleanPath(path)
 	}
 
 	if handle, params := r.lookup(req.Method, path); handle != nil {
-		req.URL.Path = path
 		if len(params) > 0 {
 			req = req.WithContext(
 				context.WithValue(req.Context(), ParamsKey, params),
@@ -305,22 +312,26 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		handle.ServeHTTP(w, req)
 		return
 	} else if req.Method != http.MethodConnect && path != "/" {
-		if r.TryFixedTrailingSlash {
+		// Moved Permanently, request with GET method
+		code := http.StatusMovedPermanently
+		if req.Method != http.MethodGet {
+			// Permanent Redirect, request with same method
+			code = http.StatusPermanentRedirect
+		}
+
+		if r.RedirectTrailingSlash {
 			var fixedPath string
+			newPath := req.URL.Path
 			if len(path) > 1 && path[len(path)-1] == '/' {
 				fixedPath = path[:len(path)-1]
+				newPath = newPath[:len(newPath)-1]
 			} else {
 				fixedPath = path + "/"
+				newPath = newPath + "/"
 			}
-
-			if handle, params := r.lookup(req.Method, fixedPath); handle != nil {
-				req.URL.Path = fixedPath
-				if len(params) > 0 {
-					req = req.WithContext(
-						context.WithValue(req.Context(), ParamsKey, params),
-					)
-				}
-				handle.ServeHTTP(w, req)
+			if handle, _ := r.lookup(req.Method, fixedPath); handle != nil {
+				req.URL.Path = newPath
+				http.Redirect(w, req, req.URL.String(), code)
 				return
 			}
 		}


### PR DESCRIPTION
Previously I had made a change that preferred using the escaped path and mutated the original request. That had unintended consequences down the line for consumers that had assumptions about whether the original URL was already escaped. In this change, there is a new flag that lets the router use the RawPath if available for route matching but leaves the original URL intact.

This PR also goes back to the original logic that preferred redirecting to the path with or without the trailing slash, if a handler exists. The previous logic implicitly fixed the URL. This also had the possibility of creating unintended consequences so I would like to remove it.

The final change in this PR is a new flag `CleanPath` that cleans the path (removes superflous slashes etc) for route matching without mutating the original URL. This isn't ideal but its less likely to cause issues and we need it for our use case.